### PR TITLE
Add side panel read-it-later extension skeleton

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,193 @@
+# Chrome Side Panel Read-It-Later Extension Specification
+
+## Problem & Goals
+- Provide a lightweight, privacy-first "read-it-later" tool embedded in Chrome's side panel.
+- Differentiates from Pocket or Reading List by operating entirely on-device, avoiding account creation, and focusing on temporary, local library management.
+- Primary target: Desktop Chrome; Chromium-based browsers such as Edge are a stretch goal.
+- No server-side account or cloud storage for MVP.
+
+## User Stories & Flows
+### MVP
+1. Click browser action or press shortcut to open side panel.
+2. Capture current article, parse into distraction-free reader view, and save locally without opening new tabs.
+3. Context menu item "Save to Later" on links and pages.
+4. Add optional tags; search saved items; mark read/unread; delete entries.
+5. Automatic expiration choices: 30, 60, or 90 days.
+
+### v1.0 Enhancements
+- Bulk import from open tabs.
+- Per-site extraction rules.
+- "Save All" on page.
+- Export library to PDF, Markdown, or EPUB.
+- Optional cross-device metadata sync.
+
+## Chrome APIs
+- `chrome.sidePanel` for side panel UI (Manifest V3 permission and open/close behavior)[1].
+- MV3 service worker orchestrates background tasks and message passing among service worker, content scripts, and side panel[2][3].
+- `chrome.offscreen` to handle DOM-dependent parsing tasks outside service worker[4].
+- Storage options: `chrome.storage.local` and `chrome.storage.sync` with quota considerations[5]; IndexedDB via Dexie for primary library store with StorageManager for persistence[6][7].
+- File System Access API for export/import workflows[8].
+- DeclarativeNetRequest for optional reader-view privacy rules, acknowledging its inability to bypass network requests or paywalls[9].
+
+## Article Extraction & Reader Mode
+- Lawful extraction only; respects site Terms of Service and excludes paywall bypass.
+- Parser options:
+  - **Mozilla Readability** (JS) – robust, MPL-2.0 licensed[10].
+  - **Postlight Parser** – alternative maintained project, Apache-2.0 licensed[11].
+- Sanitization with DOMPurify to remove dangerous markup[12].
+- Fallback heuristics for dynamic SPA sites when parsers fail.
+- Reader UI: configurable typography, light/dark/system themes, image handling, estimated read time, link footnotes.
+
+## Filtering Logic
+- Rules-based filters: domain, section, keyword, minimum word count.
+- Quick-save affordances: context menu, toolbar button, keyboard shortcut.
+- Optional on-device ranking using TF-IDF or small embeddings, no network calls.
+
+## Storage & Lifecycle
+- Data model includes URL, canonical URL, title, site, publishDate, extracted HTML, clean text, lead image, tags, read/unread state, addedAt, lastOpened, wordCount.
+- IndexedDB (Dexie) as primary store with quota awareness and eviction strategies.
+- Optional sync of metadata via `chrome.storage.sync` (limited by quotas).
+- Retention policy: items auto-purge after selected duration; manual purge available.
+- Migration plan: versioned Dexie schema upgrades.
+
+## Security, Privacy, Compliance
+- Minimal permissions: `sidePanel`, `storage`, `offscreen`, `contextMenus`, `scripting` (for content scripts), optional `declarativeNetRequest`.
+- Content sanitized via DOMPurify; strict Content Security Policy; no remote code execution.
+- Accessibility: WCAG 2.2 AA compliance for side panel and reader view.
+- **Compliance statement:** "This extension will not and must not bypass or remove paywalls, subscription requirements, login gates, or other access controls. It will only save content the user can legally access in their current session, and it will respect site terms and Chrome Web Store policies."
+
+## Recommended Tech Stack
+- Language: TypeScript.
+- UI Framework: React or Svelte for side panel; Tailwind CSS for styling.
+- Build: Vite with Plasmo or CRXJS for MV3 packaging.
+- Data: IndexedDB managed by Dexie.
+- Parsing: Mozilla Readability primary; Postlight Parser optional.
+- State: Redux Toolkit/Zustand (React) or Svelte stores.
+- Testing: Playwright for E2E; Vitest/Jest for unit tests; regression corpus for parsers.
+
+## Architecture & Components
+- **Service Worker:** lifecycle management, alarms for purge, routing of messages.
+- **Content Script:** injects into pages to capture article metadata and user triggers.
+- **Offscreen Document:** handles parsing when DOM access is required outside active tab.
+- **Side Panel App:** library management and reader UI.
+- Message passing via `chrome.runtime` messaging; robust error handling and background tasks.
+
+## Performance Targets & Local Telemetry
+- Parsing typical article < 400 ms.
+- Side panel open/render < 150 ms.
+- Memory budget suitable for 2–3k stored items.
+- Local-only analytics stored in IndexedDB; no external network calls.
+
+## MVP Acceptance Criteria & Test Plan
+- Capture, parse, render, search, tag, delete, and expire articles.
+- Cross-site tests: static pages, soft paywalls, infinite scroll sites.
+- Offline reading support.
+- Dark mode switching.
+- Keyboard shortcuts for open/save actions.
+- Playwright E2E tests covering extension flows.
+- Unit tests for parser outputs and sanitization logic.
+
+## Delivery & Risks
+- Milestones: Design → MVP Build → Parser Tuning → QA → Store Submission.
+- Risks: varying site structures, parser accuracy, storage quotas, permissions review.
+- Mitigations: fallback parsing heuristics, local quota checks, early Chrome Web Store review.
+
+## Engineering Appendices
+### manifest.json (MV3 skeleton)
+```json
+{
+  "manifest_version": 3,
+  "name": "Side Panel Reader",
+  "version": "0.1.0",
+  "permissions": ["storage", "sidePanel", "offscreen", "contextMenus", "scripting"],
+  "action": { "default_title": "Save to Later" },
+  "icons": { "48": "icons/icon48.png", "128": "icons/icon128.png" },
+  "background": { "service_worker": "background.js" },
+  "side_panel": { "default_path": "sidepanel.html" }
+}
+```
+
+### Content Script Trigger
+```js
+// content-script.js
+chrome.runtime.sendMessage({ type: 'CAPTURE_PAGE' });
+```
+
+### Message Passing
+```js
+// background.js
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'CAPTURE_PAGE') {
+    // handle capture
+  }
+});
+```
+
+### Dexie Schema
+```ts
+import Dexie, { Table } from 'dexie';
+
+interface Article {
+  url: string;
+  canonicalUrl?: string;
+  title: string;
+  site: string;
+  publishDate?: string;
+  html: string;
+  text: string;
+  leadImage?: string;
+  tags: string[];
+  read: boolean;
+  addedAt: number;
+  lastOpened?: number;
+  wordCount: number;
+}
+
+class ArticleDB extends Dexie {
+  articles!: Table<Article, string>;
+  constructor() {
+    super('articles');
+    this.version(1).stores({
+      articles: '&url, title, site, tags, read, addedAt'
+    });
+  }
+}
+```
+
+### Offscreen Document Creation
+```js
+await chrome.offscreen.createDocument({
+  url: 'offscreen.html',
+  reasons: ['DOM_PARSER'],
+  justification: 'Parse article HTML when no tab is active'
+});
+```
+
+### Readability Usage
+```js
+import { Readability } from '@mozilla/readability';
+const doc = new DOMParser().parseFromString(html, 'text/html');
+const article = new Readability(doc).parse();
+```
+
+### File Export (optional)
+```js
+const handle = await window.showSaveFilePicker({ types: [{ description: 'Markdown', accept: { 'text/markdown': ['.md'] } }] });
+const writable = await handle.createWritable();
+await writable.write(content);
+await writable.close();
+```
+
+## References
+[1] Chrome Developers. "Side Panel API". https://developer.chrome.com/docs/extensions/reference/sidePanel
+[2] Chrome Developers. "Service Workers Overview". https://developer.chrome.com/docs/extensions/service_workers
+[3] Chrome Developers. "Message Passing". https://developer.chrome.com/docs/extensions/mv3/messaging
+[4] Chrome Developers. "Offscreen Documents". https://developer.chrome.com/docs/extensions/reference/offscreen
+[5] Chrome Developers. "Storage API". https://developer.chrome.com/docs/extensions/reference/storage
+[6] Chrome Developers. "StorageManager". https://developer.mozilla.org/docs/Web/API/StorageManager/persist
+[7] Dexie.js Docs. "StorageManager". https://dexie.org/docs/StorageManager
+[8] Chrome Developers. "File System Access API". https://developer.chrome.com/docs/web-platform/file-system-access
+[9] Chrome Developers. "DeclarativeNetRequest API". https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest
+[10] Mozilla Readability (GitHub). https://github.com/mozilla/readability
+[11] Postlight Parser (GitHub). https://github.com/postlight/parser
+[12] DOMPurify (GitHub). https://github.com/cure53/DOMPurify

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,36 @@
+{
+  "manifest_version": 3,
+  "name": "Side Panel Reader",
+  "version": "0.1.0",
+  "description": "Privacy-first read-it-later tool in Chrome side panel.",
+  "permissions": [
+    "sidePanel",
+    "storage",
+    "scripting",
+    "offscreen"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "src/background.ts",
+    "type": "module"
+  },
+  "side_panel": {
+    "default_path": "src/sidepanel/index.html"
+  },
+  "action": {
+    "default_title": "Save to Read Later"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "src/contentScript.ts"
+      ],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "side-panel-reader",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@mozilla/readability": "^0.4.4",
+    "dexie": "^3.2.4",
+    "dompurify": "^3.0.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@crxjs/vite-plugin": "^0.5.0",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "@types/chrome": "^0.0.246"
+  }
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,32 @@
+import { db } from './db';
+
+async function ensureOffscreen() {
+  const has = await chrome.offscreen.hasDocument?.();
+  if (has) return;
+  await chrome.offscreen.createDocument({
+    url: chrome.runtime.getURL('src/offscreen/offscreen.html'),
+    reasons: [chrome.offscreen.Reason.DOM_PARSER],
+    justification: 'parse articles'
+  });
+}
+
+async function saveCurrentArticle(tabId: number) {
+  const response = await chrome.tabs.sendMessage(tabId, { type: 'get-page-content' });
+  if (!response) return;
+  await ensureOffscreen();
+  const parsed = await chrome.runtime.sendMessage({ type: 'extract-article', html: response.html });
+  if (!parsed) return;
+  await db.articles.add({
+    url: response.url,
+    title: parsed.title,
+    content: parsed.content,
+    addedAt: Date.now(),
+    read: false
+  });
+}
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.id) return;
+  await saveCurrentArticle(tab.id);
+  await chrome.sidePanel.open({ tabId: tab.id });
+});

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,0 +1,5 @@
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg.type === 'get-page-content') {
+    sendResponse({ html: document.documentElement.outerHTML, url: location.href });
+  }
+});

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,23 @@
+import Dexie, { Table } from 'dexie';
+
+export interface Article {
+  id?: number;
+  url: string;
+  title: string;
+  content: string;
+  addedAt: number;
+  read: boolean;
+}
+
+export class ArticlesDB extends Dexie {
+  articles!: Table<Article>;
+
+  constructor() {
+    super('articlesDB');
+    this.version(1).stores({
+      articles: '++id,url,addedAt,read'
+    });
+  }
+}
+
+export const db = new ArticlesDB();

--- a/src/offscreen/offscreen.html
+++ b/src/offscreen/offscreen.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Offscreen</title>
+  </head>
+  <body>
+    <script type="module" src="offscreen.ts"></script>
+  </body>
+</html>

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -1,0 +1,11 @@
+import { extractArticle } from '../reader';
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg.type === 'extract-article') {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(msg.html, 'text/html');
+    const result = extractArticle(doc);
+    sendResponse(result);
+  }
+  return true;
+});

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -1,0 +1,15 @@
+import { Readability } from '@mozilla/readability';
+import DOMPurify from 'dompurify';
+
+export interface ParsedArticle {
+  title: string;
+  content: string;
+}
+
+export function extractArticle(doc: Document): ParsedArticle | null {
+  const reader = new Readability(doc);
+  const parsed = reader.parse();
+  if (!parsed) return null;
+  const clean = DOMPurify.sanitize(parsed.content);
+  return { title: parsed.title, content: clean };
+}

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { db, Article } from '../db';
+
+export default function App() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [current, setCurrent] = useState<Article | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const all = await db.articles.orderBy('addedAt').reverse().toArray();
+      setArticles(all);
+    };
+    load();
+  }, []);
+
+  if (current) {
+    return (
+      <div>
+        <button onClick={() => setCurrent(null)}>Back</button>
+        <h1>{current.title}</h1>
+        <article dangerouslySetInnerHTML={{ __html: current.content }} />
+      </div>
+    );
+  }
+
+  if (!articles.length) {
+    return <p>No saved articles.</p>;
+  }
+
+  return (
+    <ul>
+      {articles.map((a) => (
+        <li key={a.id}>
+          <button onClick={() => setCurrent(a)}>{a.title}</button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Read It Later</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="main.tsx"></script>
+  </body>
+</html>

--- a/src/sidepanel/main.tsx
+++ b/src/sidepanel/main.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { extractArticle } from '../src/reader';
+
+describe('extractArticle', () => {
+  it('parses simple article', () => {
+    const html = `<html><head><title>T</title></head><body><article><h1>Title</h1><p>Hello</p></article></body></html>`;
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const result = extractArticle(doc);
+    expect(result?.title).toBe('Title');
+    expect(result?.content).toContain('Hello');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["DOM", "ES2020"],
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { crx } from '@crxjs/vite-plugin';
+import manifest from './manifest.json';
+
+export default defineConfig({
+  plugins: [react(), crx({ manifest })]
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- add initial MV3 manifest with side panel, service worker, and content script
- implement background workflow to capture current tab, parse via offscreen document, and store articles in IndexedDB
- create React side panel UI and basic parser test

## Testing
- `npm install` *(fails: 403 Forbidden for @crxjs/vite-plugin)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6898d30786b4832990e8fbe27553ef91